### PR TITLE
Add additional test for enableReinitialize

### DIFF
--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -74,12 +74,21 @@ test('increment/decrement are capped at min/max', () => {
 })
 
 describe('enableReinitialize', () => {
-  test('true: value is updated to new default if defaultValue changes', () => {
+  test('true: value is updated to new default if defaultValue changes and value has not been modified', () => {
     const {wrapper} = setup({defaultValue: 33, enableReinitialize: true})
 
     expect(wrapper.state('value')).toBe(33)
     wrapper.setProps({defaultValue: 42})
     expect(wrapper.state('value')).toBe(42)
+  })
+
+  test('true: value is not updated to new default if defaultValue changes and value has been modified', () => {
+    const {wrapper} = setup({defaultValue: 33, enableReinitialize: true})
+
+    expect(wrapper.state('value')).toBe(33)
+    wrapper.setState({value: 418})
+    wrapper.setProps({defaultValue: 42})
+    expect(wrapper.state('value')).toBe(418)
   })
 
   test('false: value remains unchanged if defaultValue changes', () => {


### PR DESCRIPTION
Just adding a test to cover the scenario where `enableReinitialize` is `true` but the value has been changed, so we should not change it to match a new `defaultValue`. This behavior was documented in the original issue (#2) but I didn't explicitly test it in the original PR (#3). Adding this test will grant additional confidence when modifying the `enableReinitialize` implementation.