### PR TITLE
Remove focused property from input props

### DIFF
--- a/src/__tests__/__snapshots__/index.js.snap
+++ b/src/__tests__/__snapshots__/index.js.snap
@@ -20,7 +20,6 @@ Object {
 
 exports[`getInputProps 1`] = `
 Object {
-  "focused": undefined,
   "onBlur": [Function],
   "onFocus": [Function],
   "pattern": "[0-9]*",
@@ -32,7 +31,6 @@ Object {
 
 exports[`getInputProps 2`] = `
 Object {
-  "focused": true,
   "onBlur": [Function],
   "onFocus": [Function],
   "pattern": "[0-9]*",

--- a/src/index.js
+++ b/src/index.js
@@ -120,7 +120,6 @@ module.exports = exports.default = class StepperPrimitive extends React.Componen
       pattern: numericPattern,
       onBlur: callAll(props.onBlur, this.handleBlur),
       onFocus: callAll(props.onFocus, this.handleFocus),
-      focused: this.state.focused,
       // When the input is focused, let the user type freely.
       // When the input isn't, lock it to the current value
       ...this.state.focused ? {} : {


### PR DESCRIPTION
I think the `focused` boolean may have been included in the properties returned from `getInputProps` by mistake. It looks like this piece of internal state is used to determine whether or not to include the `value` attribute in the input props based on the current focus. Including `focused` as a boolean in the input props results in users spreading it on to the input, which triggers the following React warning:
```
14:40:11.373 Warning: Received `true` for a non-boolean attribute `focused`.

If you want to write it to the DOM, pass a string instead: focused="true" or focused={value.toString()}.
    in input (at CountStepper.js:55)
    in span (at CountStepper.js:33)
    in StepperPrimitive (at CountStepper.js:13)
    ...continued
```
This change removes it from the input props (but not from the values passed to the `render` prop). You could also stringify the value as an alternative (which will silence the warning), but I don't believe it should be there to begin with (correct me if I'm wrong).